### PR TITLE
[#159296841] Fix casting for process.env strings

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -19,7 +19,7 @@ export const CONFIG = {
   // https://docs.google.com/document/d/1Qqe6mSfon-blHzc-ldeEHmzIkVaElKY5LtDnKiLbk80/edit
   // Used to expose services
   CONTROLLER: {
-    PORT: process.env.PAGOPAPROXY_PORT || 3000,
+    PORT: Number(process.env.PAGOPAPROXY_PORT) || 3000,
     HOST: process.env.PAGOPAPROXY_HOST || localhost,
     ROUTES: {
       RESTFUL: {
@@ -39,7 +39,7 @@ export const CONFIG = {
   // Used to communicate with PagoPA
   PAGOPA: {
     HOST: process.env.PAGOPA_HOST || localhost,
-    PORT: process.env.PAGOPA_PORT || 3001,
+    PORT: Number(process.env.PAGOPA_PORT) || 3001,
     WS_SERVICES: {
       PAGAMENTI: "/PagamentiTelematiciPspNodoservice/"
     },
@@ -54,10 +54,10 @@ export const CONFIG = {
 
   // Redis DB Server Configuration
   REDIS_DB: {
-    PORT: process.env.REDIS_DB_PORT || 6380,
+    PORT: Number(process.env.REDIS_DB_PORT) || 6380,
     HOST: process.env.REDIS_DB_URL || "redis://localhost",
     PASSWORD: process.env.REDIS_DB_PASSWORD || "ND",
-    USE_CLUSTER: process.env.REDIS_USE_CLUSTER || false
+    USE_CLUSTER: Boolean(process.env.REDIS_USE_CLUSTER) || false
   },
 
   // Timeout used to store PaymentId into redis db (AttivaRPT process)


### PR DESCRIPTION
Cast correct type from string provided by process.env into Configuration.
It's necessary to avoid error on value mapping