### PR TITLE
[159591280] Fix declaration related to idPagamento into yaml

### DIFF
--- a/api_pagopa.yaml
+++ b/api_pagopa.yaml
@@ -157,7 +157,7 @@ definitions:
       idPagamento:
         type: string
         minLength: 1
-        maxLength: 35
+        maxLength: 36
     required:
     - idPagamento
   PaymentActivationsPostRequest:


### PR DESCRIPTION
As described into paymentId examples provided by SIA, the idPayment lenght is 36 instead 35.