### PR TITLE
Add Soap Namespace prefix to qrcode elements

### DIFF
--- a/src/utils/PaymentsConverter.ts
+++ b/src/utils/PaymentsConverter.ts
@@ -2,6 +2,7 @@
  * Payments Converter
  * Data Converter for Payments Request\Responses between PagoPA and BackendAPP types
  */
+
 import { Either, left, right } from "fp-ts/lib/Either";
 import { Validation } from "io-ts";
 import { RptId } from "italia-ts-commons/lib/pagopa";
@@ -19,6 +20,7 @@ import { nodoAttivaRPT_ppt } from "../types/pagopa_api/yaml-to-ts/nodoAttivaRPT_
 import { nodoTipoCodiceIdRPT_ppt } from "../types/pagopa_api/yaml-to-ts/nodoTipoCodiceIdRPT_ppt";
 import { nodoVerificaRPT_ppt } from "../types/pagopa_api/yaml-to-ts/nodoVerificaRPT_ppt";
 import { stText35_ppt } from "../types/pagopa_api/yaml-to-ts/stText35_ppt";
+// tslint:disable:no-duplicate-string
 
 /**
  * Define NodoVerificaRPTInput (PagoPA request) using information provided by BackendApp
@@ -186,28 +188,36 @@ function getCodiceIdRpt(rptId: RptId): nodoTipoCodiceIdRPT_ppt {
   switch (rptId.paymentNoticeNumber.auxDigit) {
     case "0":
       return {
-        CF: rptId.organizationFiscalCode,
-        AuxDigit: rptId.paymentNoticeNumber.auxDigit,
-        CodStazPA: rptId.paymentNoticeNumber.applicationCode,
-        CodIUV: rptId.paymentNoticeNumber.iuv13
+        "qrc:QrCode": {
+          "qrc:CF": rptId.organizationFiscalCode,
+          "qrc:AuxDigit": rptId.paymentNoticeNumber.auxDigit,
+          "qrc:CodStazPA": rptId.paymentNoticeNumber.applicationCode,
+          "qrc:CodIUV": rptId.paymentNoticeNumber.iuv13
+        }
       };
     case "1":
       return {
-        CF: rptId.organizationFiscalCode,
-        AuxDigit: rptId.paymentNoticeNumber.auxDigit,
-        CodIUV: rptId.paymentNoticeNumber.iuv17
+        "qrc:QrCode": {
+          "qrc:CF": rptId.organizationFiscalCode,
+          "qrc:AuxDigit": rptId.paymentNoticeNumber.auxDigit,
+          "qrc:CodIUV": rptId.paymentNoticeNumber.iuv17
+        }
       };
     case "2":
       return {
-        CF: rptId.organizationFiscalCode,
-        AuxDigit: rptId.paymentNoticeNumber.auxDigit,
-        CodIUV: rptId.paymentNoticeNumber.iuv15
+        "qrc:QrCode": {
+          "qrc:CF": rptId.organizationFiscalCode,
+          "qrc:AuxDigit": rptId.paymentNoticeNumber.auxDigit,
+          "qrc:CodIUV": rptId.paymentNoticeNumber.iuv15
+        }
       };
     case "3":
       return {
-        CF: rptId.organizationFiscalCode,
-        AuxDigit: rptId.paymentNoticeNumber.auxDigit,
-        CodIUV: rptId.paymentNoticeNumber.iuv13
+        "qrc:QrCode": {
+          "qrc:CF": rptId.organizationFiscalCode,
+          "qrc:AuxDigit": rptId.paymentNoticeNumber.auxDigit,
+          "qrc:CodIUV": rptId.paymentNoticeNumber.iuv13
+        }
       };
   }
 }

--- a/src/utils/__tests__/PaymentConverter.test.ts
+++ b/src/utils/__tests__/PaymentConverter.test.ts
@@ -4,7 +4,7 @@ import { ErrorMessagesCtrlEnum } from "../../types/ErrorMessagesCtrlEnum";
 import * as PaymentsConverter from "../PaymentsConverter";
 import * as MockedData from "./MockedData";
 
-// ts-lint:disable:max-line-length
+// tslint:disable:max-line-length no-duplicate-string
 
 describe("getNodoVerificaRPTInput", () => {
   it(" should return a correct NodoVerificaRPTInput with auxDigit=0", () => {
@@ -39,10 +39,12 @@ describe("getNodoVerificaRPTInput", () => {
       "QR-CODE"
     );
     expect(errorOrNodoVerificaRPTInput.value.codiceIdRPT).toMatchObject({
-      CF: MockedData.aRptId0.organizationFiscalCode,
-      CodStazPA: MockedData.applicationCode,
-      AuxDigit: MockedData.aRptId0.paymentNoticeNumber.auxDigit,
-      CodIUV: MockedData.iuv13
+      "qrc:QrCode": {
+        "qrc:CF": MockedData.aRptId0.organizationFiscalCode,
+        "qrc:CodStazPA": MockedData.applicationCode,
+        "qrc:AuxDigit": MockedData.aRptId0.paymentNoticeNumber.auxDigit,
+        "qrc:CodIUV": MockedData.iuv13
+      }
     });
     expect(errorOrNodoVerificaRPTInput.value.codiceContestoPagamento).toMatch(
       MockedData.aCodiceContestoPagamento
@@ -81,9 +83,11 @@ describe("getNodoVerificaRPTInput", () => {
       "QR-CODE"
     );
     expect(errorOrNodoVerificaRPTInput.value.codiceIdRPT).toMatchObject({
-      CF: MockedData.aRptId1.organizationFiscalCode,
-      AuxDigit: MockedData.aRptId1.paymentNoticeNumber.auxDigit,
-      CodIUV: MockedData.iuv17
+      "qrc:QrCode": {
+        "qrc:CF": MockedData.aRptId1.organizationFiscalCode,
+        "qrc:AuxDigit": MockedData.aRptId1.paymentNoticeNumber.auxDigit,
+        "qrc:CodIUV": MockedData.iuv17
+      }
     });
     expect(errorOrNodoVerificaRPTInput.value.codiceContestoPagamento).toMatch(
       MockedData.aCodiceContestoPagamento
@@ -122,9 +126,11 @@ describe("getNodoVerificaRPTInput", () => {
       "QR-CODE"
     );
     expect(errorOrNodoVerificaRPTInput.value.codiceIdRPT).toMatchObject({
-      CF: MockedData.aRptId2.organizationFiscalCode,
-      AuxDigit: MockedData.aRptId2.paymentNoticeNumber.auxDigit,
-      CodIUV: MockedData.iuv15
+      "qrc:QrCode": {
+        "qrc:CF": MockedData.aRptId2.organizationFiscalCode,
+        "qrc:AuxDigit": MockedData.aRptId2.paymentNoticeNumber.auxDigit,
+        "qrc:CodIUV": MockedData.iuv15
+      }
     });
     expect(errorOrNodoVerificaRPTInput.value.codiceContestoPagamento).toMatch(
       MockedData.aCodiceContestoPagamento
@@ -163,9 +169,11 @@ describe("getNodoVerificaRPTInput", () => {
       "QR-CODE"
     );
     expect(errorOrNodoVerificaRPTInput.value.codiceIdRPT).toMatchObject({
-      CF: MockedData.aRptId3.organizationFiscalCode,
-      AuxDigit: MockedData.aRptId3.paymentNoticeNumber.auxDigit,
-      CodIUV: MockedData.iuv13
+      "qrc:QrCode": {
+        "qrc:CF": MockedData.aRptId3.organizationFiscalCode,
+        "qrc:AuxDigit": MockedData.aRptId3.paymentNoticeNumber.auxDigit,
+        "qrc:CodIUV": MockedData.iuv13
+      }
     });
     expect(errorOrNodoVerificaRPTInput.value.codiceContestoPagamento).toMatch(
       MockedData.aCodiceContestoPagamento
@@ -271,10 +279,12 @@ describe("getNodoAttivaRPTInput", () => {
     // Check input content
     expect(errorOrNodoAttivaRPTInput.value).toMatchObject({
       codiceIdRPT: {
-        CF: "12345678901",
-        AuxDigit: "0",
-        CodIUV: "1234567890123",
-        CodStazPA: "12"
+        "qrc:QrCode": {
+          "qrc:CF": "12345678901",
+          "qrc:AuxDigit": "0",
+          "qrc:CodIUV": "1234567890123",
+          "qrc:CodStazPA": "12"
+        }
       }
     });
     expect(errorOrNodoAttivaRPTInput.value).toHaveProperty(

--- a/src/wsdl/NodoPerPsp.wsdl
+++ b/src/wsdl/NodoPerPsp.wsdl
@@ -11,6 +11,7 @@
   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
   xmlns:tns="http://PuntoAccessoPSP.spcoop.gov.it/servizi/PagamentiTelematiciPspNodo" 
   xmlns:pay_i="http://www.digitpa.gov.it/schemas/2011/Pagamenti/" 
+	xmlns:qrc="http://PuntoAccessoPSP.spcoop.gov.it/QrCode"
   targetNamespace="http://PuntoAccessoPSP.spcoop.gov.it/servizi/PagamentiTelematiciPspNodo">
 <!--   xmlns:pay_j="http://www.cnipa.gov.it/schemas/2010/Pagamenti/Ack_1_0/" --> 
   


### PR DESCRIPTION
Add namespace prefix to qrcode elements on soap messages, as described by examples provided by SIA.

```
<codiceIdRPT>
  <CF>12345678901</CF>
  <AuxDigit>0</AuxDigit>
  <CodStazPA>01</CodStazPA>
  <CodIUV>1351313304188</CodIUV>
</codiceIdRPT>
```

changes as following:
```
<codiceIdRPT>
  <qrc:QrCode>  
    <qrc:CF>12345678901</qrc:CF>
    <qrc:AuxDigit>0</qrc:AuxDigit>
    <qrc:CodStazPA>01</qrc:CodStazPA>
    <qrc:CodIUV>1111111111111</qrc:CodIUV>
  </qrc:QrCode>  
</codiceIdRPT>
```